### PR TITLE
Fix wrapping in footer

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,11 +27,13 @@
     "i18next-http-backend": "^3.0.2",
     "inflection": "^3.0.2",
     "luxon": "^3.7.2",
+    "prop-types": "^15.8.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-dropzone-esm": "^15.2.0",
     "react-i18next": "^16.0.0",
-    "react-router": "^7.9.1"
+    "react-router": "^7.9.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/react": "^19.1.13",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -80,7 +80,7 @@ function App () {
                   />
                 </Routes>
               </AppShell.Main>
-              <AppShell.Footer pos='relative' h='12.875rem' bd='none' bg='var(--mantine-color-light-background)'>
+              <AppShell.Footer pos='relative' bd='none' bg='var(--mantine-color-light-background)'>
                 <Footer />
               </AppShell.Footer>
             </AppShell>

--- a/client/src/Footer.jsx
+++ b/client/src/Footer.jsx
@@ -1,4 +1,4 @@
-import { Anchor, Container, Image, Text } from '@mantine/core';
+import { Anchor, Container, Group, Image, Text } from '@mantine/core';
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 
@@ -9,7 +9,11 @@ function Footer () {
       <Text mb='.75rem' fz='xs' lh='1rem' c='var(--mantine-color-text-secondary)'>{t('footer.providedBy')}</Text>
       <Image mb='.5rem' src='/assets/sfcivictech.png' w={138} />
       <Text fz='sm'>{t('footer.partnershipLine1')}<br />{t('footer.partnershipLine2')}</Text>
-      <Anchor component={Link} td='underline' fz='sm' to='https://sf.gov/LVProgram'>{t('footer.permitProgramSite')}</Anchor> <Anchor component={Link} ms='xl' td='underline' fz='sm' to='/privacy'>{t('footer.privacyPolicy')}</Anchor> <Anchor component={Link} ms='xl' td='underline' fz='sm' to='/disclaimer'>{t('footer.disclaimer')}</Anchor>
+      <Group justify='space-between' align='center' gap='0'>
+        <Anchor component={Link} td='underline' fz='sm' to='https://sf.gov/LVProgram'>{t('footer.permitProgramSite')}</Anchor>
+        <Anchor component={Link} td='underline' fz='sm' to='/privacy'>{t('footer.privacyPolicy')}</Anchor>
+        <Anchor component={Link} td='underline' fz='sm' to='/disclaimer'>{t('footer.disclaimer')}</Anchor>
+      </Group>
     </Container>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,11 +33,13 @@
         "i18next-http-backend": "^3.0.2",
         "inflection": "^3.0.2",
         "luxon": "^3.7.2",
+        "prop-types": "^15.8.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-dropzone-esm": "^15.2.0",
         "react-i18next": "^16.0.0",
-        "react-router": "^7.9.1"
+        "react-router": "^7.9.1",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@types/react": "^19.1.13",


### PR DESCRIPTION
Put a Group around the Anchors in the footer so that they flex on one line, with space between. 
Remove the h prop on the Footer in App.jsx, since that was causing some blank space if the footer content wasn't exactly that height. 
Add missing prop-types and uuid packages.

Initial issue:
<img width="519" height="271" alt="image" src="https://github.com/user-attachments/assets/cda1b64c-d10b-458e-8955-e34001e2fb04" />
